### PR TITLE
Escape spaces in tag search queries

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -128,7 +128,7 @@
 				<key>concurrently</key>
 				<false/>
 				<key>escaping</key>
-				<integer>102</integer>
+				<integer>103</integer>
 				<key>script</key>
 				<string>orig_query={query}
 echo $orig_query


### PR DESCRIPTION
I thought #28  was an issue with `.` characters in tag names, but actually looks like it was unencoded spaces.

This fixes the problem.